### PR TITLE
cleanup - no changes to behavior on provided examples, possible small improvement in quality of kmer spectral alignment for some edge cases

### DIFF
--- a/app/src/main/java/org/wbdbga/AlignmentResult.java
+++ b/app/src/main/java/org/wbdbga/AlignmentResult.java
@@ -21,7 +21,7 @@ package org.wbdbga;
 import java.util.*;
 
 /**
-   Class returned to score alignments, such as the overlap alignment used to remove overlapping redundant content in the tips of contigs from circular sequences, or if attempting to join de Bruijn contigs using dynamic programming based overlap alignment as a finishing step is enabled. See OverlapAlignmentTest#overlapAlignTestWithoutErrors or #overlapAlignTestWithErrors for an illustration of how this result works and can be used.
+   Class returned to score alignments, such as the overlap alignment used to remove overlapping redundant content in the tips of contigs from circular sequences. See OverlapAlignmentTest#overlapAlignTestWithoutErrors or #overlapAlignTestWithErrors for an illustration of how this result works and can be used.
 
    @see org.wbdbga.OverlapAlignment#align
    @see org.wbdbga.DeBruijnGenomeAssembler#removeCircularEndOverlapOnContigsAndConvertToStrings 

--- a/app/src/main/java/org/wbdbga/Contig.java
+++ b/app/src/main/java/org/wbdbga/Contig.java
@@ -79,7 +79,6 @@ public final class Contig {
 
         // generate contig sequence
         StringBuilder sb = new StringBuilder("");
-        StringBuilder sb2 = new StringBuilder("");
 
         for (int i = 0; i < this.nodeIndices.size(); i++) {
             int nodeIdx = this.nodeIndices.get(i);

--- a/app/src/main/java/org/wbdbga/DeBruijnGenomeAssembler.java
+++ b/app/src/main/java/org/wbdbga/DeBruijnGenomeAssembler.java
@@ -66,7 +66,8 @@ public class DeBruijnGenomeAssembler {
     }
 
     /**
-       Method that triggers assembly, just make sure readInParameters() is called first. Finds a good value of k and performs assembly if possible, outputting the result to stdout in fasta format labeling contigs.
+       Method that triggers assembly, just make sure readInParameters() is called first. Finds a good value of k and performs assembly if possible, returning a list of contig strings in descending order of length.
+       @return List of assembled contig strings in descending order of contig length. For smaller genomes, the entire assembly may be in the first contig. Usually short contigs less than 500bp at the end can be ignored but are included for completeness.
      */
     public List<String> solve() {
         try {
@@ -131,7 +132,10 @@ public class DeBruijnGenomeAssembler {
     /**
        Run the de Bruijn assembler!
        See the README.md for instructions, but "java -jar ./app/build/libs/app.jar &lt; examples/noisyCarsonellaRuddiiReads.txt" is a working example (after following instructions in ./util/README.md to create examples/noisyCarsonellaRuddiiReads.txt and running "./gradlew build").
-       @param args command line arguments, currently only "--k"/"--kmer_size_starting_guess" is supported
+
+       Outputs the assembled contigs to standard output after showing the assembly process and writes the latest assembly to either "output.fasta" in the current directory or whatever file is specified using the "--output_fasta" argument.
+
+       @param args command line arguments, currently only "--output_fasta","--k", and "--kmer_size_starting_guess" are supported
      */
     public static void main(String[] args) {
         System.out.println("DeBruijnGenomeAssembler Copyright (C) 2025 William Bruns\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\nYou should have received a copy of the GNU General Public License\nalong with this program.  If not, see https://www.gnu.org/licenses/.\nThis is free software, and you are welcome to redistribute it\nunder certain conditions, see the GNU General Public License for details.\n");
@@ -155,7 +159,7 @@ public class DeBruijnGenomeAssembler {
                 if (i >= args.length) {
                     throw new IllegalArgumentException("'--kmer_size_starting_guess' must be followed by an integer specifying the kmer size to use, e.g. '--kmer_size_starting_guess 40'");
                 }
-                startingKmerSizeGuess = Integer.valueOf(args[i]);
+                startingKmerSizeGuess = Integer.parseInt(args[i]);
                 if (startingKmerSizeGuess < 1 || startingKmerSizeGuess > 100) {
                     throw new IllegalArgumentException("Overriding the kmer_size_starting_guess must be with an integer between 1 and 100 inclusive");
                 }

--- a/app/src/main/java/org/wbdbga/DeBruijnGraphContigSolver.java
+++ b/app/src/main/java/org/wbdbga/DeBruijnGraphContigSolver.java
@@ -95,7 +95,7 @@ public final class DeBruijnGraphContigSolver {
                 // note we do not check whether we already visited here since these are one-in-one-out nodes so are excluded from nonOneInOneOutNodes
                 // they cannot be visited multiple times as they are one-in-one-out so have only one parent non-one-in-one-out node which we visit once
                 while (otherNodeIdx != null && dbg.outdegree[otherNodeIdx] == 1 && dbg.indegree[otherNodeIdx] == 1) {
-                    if (otherNodeIdx != null && dbg.adjacency[otherNodeIdx] != null && dbg.adjacency[otherNodeIdx].size() > 0) {
+                    if (dbg.adjacency[otherNodeIdx] != null && dbg.adjacency[otherNodeIdx].size() > 0) {
                         otherNodeIdx = dbg.adjacency[otherNodeIdx].get(0);
                         currentPath.add(otherNodeIdx);
                         visitedNode[otherNodeIdx] = true;
@@ -173,7 +173,7 @@ public final class DeBruijnGraphContigSolver {
         // sort descending order of contig length
         Collections.sort(this.contigs, new Comparator<Contig>() {
                 public int compare(Contig a, Contig b) {
-                    return -1 * Integer.valueOf(a.getEdgeLength()).compareTo(Integer.valueOf(b.getEdgeLength()));
+                    return Integer.compare(b.getEdgeLength(), a.getEdgeLength());
                 }
             });
     }

--- a/app/src/main/java/org/wbdbga/DeBruijnKmers.java
+++ b/app/src/main/java/org/wbdbga/DeBruijnKmers.java
@@ -89,7 +89,7 @@ public class DeBruijnKmers {
     /**
        Large genomes with distinct kmer count greater than this are treated differently due to assumptions of lower coverage and potential problems keeping them in memory.
      */
-    final int LARGE_GENOME_KMER_THRESHOLD = 5000000;
+    static final int LARGE_GENOME_KMER_THRESHOLD = 5000000;
 
     // two flags to control during unit testing
     // sometimes we need to disable trie corrections to allow errors through when setting up unit tests for other parts of the code
@@ -244,8 +244,8 @@ public class DeBruijnKmers {
     private void recomputeTotalAndAverageKmerReadCoverage() {
         totalReadCoverageForKmers = 0;
 
-        for (ValueComparedByteArray kmer : kmerCoverageMap.keySet()) {
-            totalReadCoverageForKmers += (int)kmerCoverageMap.get(kmer);
+        for (Map.Entry<ValueComparedByteArray, Byte> kmerCoverageEntry : kmerCoverageMap.entrySet()) {
+            totalReadCoverageForKmers += (int)kmerCoverageEntry.getValue();
         }
 
         int numDistinctKmers = kmerCoverageMap.keySet().size();
@@ -262,11 +262,13 @@ public class DeBruijnKmers {
         List<ValueComparedByteArray> kmersToRemove = new LinkedList<ValueComparedByteArray>();
 
         boolean largeGenomeKmerThresholdReached = false;
-        if (kmerCoverageMap.keySet().size() > LARGE_GENOME_KMER_THRESHOLD) {
+        int kmerCoverageMapKmerCount = kmerCoverageMap.keySet().size();
+        if (kmerCoverageMapKmerCount > LARGE_GENOME_KMER_THRESHOLD) {
             largeGenomeKmerThresholdReached = true;
         }
-
-        for (ValueComparedByteArray kmer : kmerCoverageMap.keySet()) {
+        
+        for (Map.Entry<ValueComparedByteArray, Byte> kmerCoverageEntry : kmerCoverageMap.entrySet()) {
+            ValueComparedByteArray kmer = kmerCoverageEntry.getKey();
             // TODO make the minimum threshold here configurable as this may be something that prevents certain datasets from being assembled due to being too aggressive
             // someone who is not getting decent sized contigs should be able to turn this off / make this less aggressive to see if that fixes their problem.
             int threshold = (int)Math.min(averageReadCoverageForKmers / 4, 6); // was experimenting with being very aggressive on dropping kmers before the final round (when the reduced kmer pool is used for kmer spectral alignment). however it caused a disconnected de bruijn graph (11K nodes out of 5,062,927 nodes), per my current threshold. I ran it with this aggressive mode again and raised the imbalance node threshold and checked the contigs. There was not an improvement there, so I set this threshold lower and for large genomes just use threshold 1.
@@ -282,11 +284,11 @@ public class DeBruijnKmers {
                 threshold = 1;
             }
 
-            if (kmerCoverageMap.get(kmer) <= Byte.valueOf((byte)Math.max(1, threshold))) {
+            if (kmerCoverageEntry.getValue() <= Byte.valueOf((byte)Math.max(1, threshold))) {
                 kmersToRemove.add(kmer);
                 numToRemove++;
             }
-            if (numToRemove >= 500000 && kmerCoverageMap.keySet().size() > 1000000) {
+            if (numToRemove >= 500000 && kmerCoverageMapKmerCount > 1000000) {
                 break; // otherwise we are getting too close to the memory limit
             }
         }
@@ -496,8 +498,6 @@ public class DeBruijnKmers {
             //System.out.println("Called putKmerReadAndIndexPairForKmerString with " + kmer + ")");
             kmerReadAndIndexPair = putKmerReadAndIndexPairForKmerString(kmer, readIdx, offset);
 
-            int[] kmerReadAndIndexPairInt = GenomeSequenceEncodingUtil.decodeKmerBytesToIntArray(kmerReadAndIndexPair);
-
             int count = ((int)kmerCoverageMap.getOrDefault(ValueComparedByteArray.from(kmerReadAndIndexPair), (byte)0)) + 1;
 
             totalReadCoverageAdded++;
@@ -617,13 +617,10 @@ public class DeBruijnKmers {
             throw new NotInitializedException("kmerCoverageMap is not yet loaded. setupFromReadStringsAndSpecifiedK must be called before this method.");
         }
 
-        int numDistinctKmers = kmerCoverageMap.keySet().size();
-
         kmerHashCodeToReadIndexAndSubstringIndexMap = null; // no longer needed! (we will replace it with (k-1)-mers in the map as we break kmers observed into nodes for prefix and suffix)
         //System.gc();
         kmerHashCodeToReadIndexAndSubstringIndexMap = new HashMap<Integer, List<ValueComparedByteArray>>();
 
-        // similar to what I did after splitting the text into K-mers in DeBruijnString.java ("4. Construct the de Bruijn Graph of a String")
         // except here we do not handle kmer strings explicitly (redundant; requires too much memory) so bit more complicated to handle indices only (and replace indices with first place it occurs so that indices are unique even if the kmer occurs across many reads).
         int numKmersChecked = 0;
         int numKmersToCheck = kmerCoverageMap.keySet().size();
@@ -698,25 +695,25 @@ public class DeBruijnKmers {
         return debruijnMap;
     }
 
-    class NotInitializedException extends RuntimeException {
+    static class NotInitializedException extends RuntimeException {
         public NotInitializedException(String message) {
             super(message);
         }
     }
 
-    class CorruptedReadIndexAndSubstringIndexMapException extends RuntimeException {
+    static class CorruptedReadIndexAndSubstringIndexMapException extends RuntimeException {
         public CorruptedReadIndexAndSubstringIndexMapException(String message) {
             super(message);
         }
     }
 
-    class OutOfRangeReadIndexException extends RuntimeException {
+    static class OutOfRangeReadIndexException extends RuntimeException {
         public OutOfRangeReadIndexException(String message) {
             super(message);
         }
     }
 
-    class OutOfRangeReadOffsetException extends RuntimeException {
+    static class OutOfRangeReadOffsetException extends RuntimeException {
         public OutOfRangeReadOffsetException(String message) {
             super(message);
         }

--- a/app/src/main/java/org/wbdbga/DeBruijnLowCoverageBubbleRemover.java
+++ b/app/src/main/java/org/wbdbga/DeBruijnLowCoverageBubbleRemover.java
@@ -26,7 +26,7 @@ import java.util.*;
  */
 public final class DeBruijnLowCoverageBubbleRemover {
     DeBruijnGraph dbg;
-    final double RELATIVE_COVERAGE_THRESHOLD_TO_DROP_BUBBLE_EDGES = 0.80;
+    static final double RELATIVE_COVERAGE_THRESHOLD_TO_DROP_BUBBLE_EDGES = 0.80;
     boolean VERBOSE = false;
 
     public DeBruijnLowCoverageBubbleRemover(DeBruijnGraph dbg) {

--- a/app/src/main/java/org/wbdbga/DeBruijnLowCoverageTipRemover.java
+++ b/app/src/main/java/org/wbdbga/DeBruijnLowCoverageTipRemover.java
@@ -28,7 +28,7 @@ Miller, J. R., Koren, S., Sutton, G. (2010). Assembly algorithms for next-genera
 public final class DeBruijnLowCoverageTipRemover {
     boolean VERBOSE = false;
     DeBruijnGraph dbg;
-    final double RELATIVE_COVERAGE_THRESHOLD_TO_DROP_TIP_EDGES = 0.50;
+    static final double RELATIVE_COVERAGE_THRESHOLD_TO_DROP_TIP_EDGES = 0.50;
 
     /**
        Constructs a DeBruijnLowCoverageTipRemover from an initialized DeBruijnGraph. Make sure to pass a non-empty initialized DeBruijnGraph or you will get an IllegalArgumentException. Call solve() to perform the low coverage tip removal.
@@ -55,9 +55,6 @@ public final class DeBruijnLowCoverageTipRemover {
 
         for (int i = 0; i < dbg.numNodes; i++) {
             if (isTip(i)) {
-                if (VERBOSE) {
-                    //System.out.println("tip: " + dbg.nodeValues.get(i));
-                }
                 tipNodes.add(i);
             }
         }
@@ -103,9 +100,9 @@ public final class DeBruijnLowCoverageTipRemover {
     }
 
     /**
-       Removes a tip node and returns the upstream node, call this repeatedly after checking isTip to remove a low coverage branch/tip from the de Bruijn graph.
+       Removes a tip node and returns the upstream node, call this repeatedly after checking isTip to remove a low coverage branch/tip from the de Bruijn graph (returning -1 means no further nodes should be removed in this way due to reaching the coverage threshold on the edges.)
        @param nodeIdx the index of the node to remove (must be a tip node or will generate exception!)
-       @return the index of the upstream node which could be the parent or the child depending on what type of tip this is
+       @return the index of the upstream node which could be the parent or the child depending on what type of tip this is (returns -1 if tip removal was aborted, e.g. due to exceeding coverage threshold at the next node)
      */
     public int removeNodeAtTipAndReturnNextNodeIdx(int nodeIdx) {
         if (Math.max(dbg.indegree[nodeIdx], dbg.outdegree[nodeIdx]) != 1) {
@@ -119,10 +116,6 @@ public final class DeBruijnLowCoverageTipRemover {
         if (dbg.outdegree[nodeIdx] == 0) {
             if (dbg.backAdjacency[nodeIdx] == null || ((List<Integer>)dbg.backAdjacency[nodeIdx]).size() != 1) {
                 throw new BackAdjacencyEntryCorruptedException("indegree is one but backAdjacency does not have exactly one entry for nodeIdx==" + nodeIdx);
-            } else {
-                if (VERBOSE) {
-                    //System.out.println("removing " + nodeIdx + " (" + dbg.nodeValues.get(nodeIdx) + ")");
-                }
             }
 
             int parentIdx = dbg.backAdjacency[nodeIdx].get(0);
@@ -131,8 +124,7 @@ public final class DeBruijnLowCoverageTipRemover {
                 throw new ParentNodeAdjacencyEntryForChildMissingException("could not find reference to this node in parent adjacency");
             }
 
-            double averageCoverageToUse = dbg.averageReadCoverage;//(dbg.averageCoverageForRetainedEdges != null && !Double.isNaN(dbg.averageCoverageForRetainedEdges)) ? dbg.averageCoverageForRetainedEdges : dbg.averageReadCoverage;
-            //if (VERBOSE) { System.out.println("averageCoverageToUse: " + averageCoverageToUse); }
+            double averageCoverageToUse = dbg.averageReadCoverage;
             if (dbg.adjacencyCoverageCount[parentIdx].get(parentAdjacencyToThisIdx) > averageCoverageToUse * RELATIVE_COVERAGE_THRESHOLD_TO_DROP_TIP_EDGES) {
                 return -1;
             }
@@ -146,11 +138,8 @@ public final class DeBruijnLowCoverageTipRemover {
             if (dbg.adjacency[parentIdx].size() != dbg.adjacencyCoverageCount[parentIdx].size()) { throw new DeBruijnGraph.DeBruijnGraphCorruptionException("adjacency related data structures sizes do not match which should never happen"); }
             return parentIdx;
         } else {
-            if (VERBOSE) {
-                //System.out.println("removing " + nodeIdx + " (" + dbg.nodeValues.get(nodeIdx) + ")");
-            }
             int childIdx = dbg.adjacency[nodeIdx].get(0);
-            double averageCoverageToUse = dbg.averageReadCoverage;//(dbg.averageCoverageForRetainedEdges != null && !Double.isNaN(dbg.averageCoverageForRetainedEdges)) ? dbg.averageCoverageForRetainedEdges : dbg.averageReadCoverage;
+            double averageCoverageToUse = dbg.averageReadCoverage;
             if (dbg.adjacencyCoverageCount[nodeIdx].get(0) > averageCoverageToUse * RELATIVE_COVERAGE_THRESHOLD_TO_DROP_TIP_EDGES) {
                 return -1;
             }

--- a/app/src/main/java/org/wbdbga/KmerSizeSelector.java
+++ b/app/src/main/java/org/wbdbga/KmerSizeSelector.java
@@ -41,7 +41,7 @@ public class KmerSizeSelector {
     static final boolean VERBOSE = true;
     //final boolean PRINT_DEBRUIJN_IN_GRAPHVIZ = false;
     Integer numInputLines = null;
-    final String BEST_SOLUTION_SO_FAR_TEMPORARY_FILENAME_PREFIX = "deBruijnGraphForBestSolutionSoFarTmp";
+    static final String BEST_SOLUTION_SO_FAR_TEMPORARY_FILENAME_PREFIX = "deBruijnGraphForBestSolutionSoFarTmp";
 
     /**
        Construct a KmerSizeSelector, which can be followed by calling readInParameters(k) with your initial guess at k to load the genome reads from standard input, then solve(), then getDeBruijnGraph() to get the resulting de Bruijn graph, ready for extracting contigs using DeBruijnGraphContigSolver.
@@ -250,7 +250,6 @@ This method will read from stdin reads as 1 read per line with consistent read l
                 System.out.println("Found a candidate. k == " + k + " has n50 == " + n50 + " (NOT computed vs a reference genome but is relative to DeBruijn graph formed from reads as this is a de novo assembler).");
             }
 
-            // TODO also support commandline argument to just use the provided value and not perform a search
             if (kWithBestEstimatedN50WithoutReference == k) {
                 foundKValue = true;
                 bestDbgSoFar = dbg;

--- a/app/src/main/java/org/wbdbga/KmerTrieFilterReads.java
+++ b/app/src/main/java/org/wbdbga/KmerTrieFilterReads.java
@@ -186,11 +186,17 @@ public final class KmerTrieFilterReads {
                     ReadSpectralAlignmentResult newResult = checkRead(readIdx);
                     //System.out.println("previously read idx " + readIdx + ", charIdx " + charIdx + " had " + result.numMisalignedKmers + " now it has " + newResult.numMisalignedKmers + " misaligned kmers");
                     if (newResult.numMisalignedKmers < result.numMisalignedKmers - MIN_KMER_BREAKS_REQUIRED_CORRECTED_PER_UPDATE || (newResult.numMisalignedKmers == 0 && result.numMisalignedKmers != 0)) {
-                        bestCharSubstitution = c;
-                        bestNumMisalignedKmers = newResult.numMisalignedKmers;
-                    } else {
+                        // almost always there is at most one option per read position satisfying the condition above (not a good sign if ambiguous),
+                        // but if we have multiple candidate character substitutions satisfying the required improvement condition,
+                        // we can take the best one
+                        if (bestNumMisalignedKmers == null || newResult.numMisalignedKmers < bestNumMisalignedKmers) {
+                            bestCharSubstitution = c;
+                            bestNumMisalignedKmers = newResult.numMisalignedKmers;
+                        }
+                    } 
+                    //else {
                         //System.out.println("read idx " + readIdx + ", charIdx " + charIdx + " -> not enough of an improvement to make a correction");
-                    }
+                    //}
                 }
 
                 this.reads.set(readIdx, oldReadBytes);
@@ -214,17 +220,6 @@ public final class KmerTrieFilterReads {
 
         System.out.println("number spectrally misaligned reads (not amenable to point correction - generally low alignment): " + spectrallyMisalignedReadsToIgnore.size());
         System.out.println("number corrections recommended: " + readCorrectionsToMake.size());
-
-        /**
-         // we need to update our kmer references for this update if the kmer was first encountered on this particular read and is referenced elsewhere. we have not been doing these read removals at this time.
-         int offset = 0;
-         List<Integer> readsToRemove = new ArrayList<Integer>(spectrallyMisalignedReadsToIgnore);
-         Collections.sort(readsToRemove);
-
-         for (Integer misalignedReadToRemove : readsToRemove) {
-         this.reads.remove(misalignedReadToRemove - offset++);
-         }
-        **/
 
         return readCorrectionsToMake;
     }

--- a/app/src/main/java/org/wbdbga/OverlapAlignment.java
+++ b/app/src/main/java/org/wbdbga/OverlapAlignment.java
@@ -153,8 +153,12 @@ Perform overlap alignment of two strings, s and t, and return the score, the end
 
         int i = len1 - 1;
         int j = len2 - 1;
+
+        // sb1, sb2 are left in here in case someone wants to uncomment
+        // the lines later down to print out the alignment details
         StringBuilder sb1 = new StringBuilder("");
         StringBuilder sb2 = new StringBuilder("");
+
         int originateI = -1;
         int originateJ = -1;
         while (j > 0 || i > 0) {
@@ -191,6 +195,12 @@ Perform overlap alignment of two strings, s and t, and return the score, the end
                 throw new InvalidAlignmentStepChoice("Error unexpected choiceChar " + choiceChar + " at i==" + i + ", j==" + j +".");
             }
         }
+
+        // If debugging or curious about a particular alignment, it may be useful to uncomment the following two lines:
+        // ```
+        // System.out.println("aligned s: " + sb1);
+        // System.out.println("aligned t: " + sb2);
+        // ```
 
         // For e.g. s shorter than t, alignment beginning after the end of s means it did not align
         // subtract extra 1 for " " appended in beginning


### PR DESCRIPTION
- remove unused code
- update out of date comments/documentation (incl removing early mention of a feature withheld from this version; not secret just not quality checked enough to go out)
- avoid unnecessary null check
- iterate on entrySet instead of keySet followed by get call (speedup, no behavior change)
- replace Integer.valueOf unboxed to primitive with parseInt (more efficient, same behavior)
- possible small improvement to kmer spectral alignment: when multiple characters could improve alignment of a read to the solid kmer spectrum choose the best one instead of any one (almost never an option, bad if ambiguous, and no change observed on E coli or other examples I have on hand, but should be better behavior)

Noting that the reason the last commit included changes to mark classes final was for classes for where I do not expect subclassing to occur and where the constructor threw exceptions to avoid subclasses getting around the validation or other issues (no change in behavior).